### PR TITLE
fixed wrong parameters variable

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -107,7 +107,7 @@ axiod.request = ({
 
   // Add params to Request Config Url
   if (_params) {
-    url = urlJoin(url, `?${params}`);
+    url = urlJoin(url, `?${_params}`);
   }
 
   // Add body to Request Config


### PR DESCRIPTION
when adding a params object, the request was sent to "url?[Object object]"