### PR TITLE
Add fix for instance creation

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,11 +1,6 @@
 import { urlJoin } from "https://deno.land/x/url_join/mod.ts";
 
-import type { 
-  IRequest,
-  IConfig,
-  Data,
-  IAxiodResponse,
-} from "./interfaces.ts";
+import type { Data, IAxiodResponse, IConfig, IRequest } from "./interfaces.ts";
 import { methods } from "./helpers.ts";
 
 function axiod(
@@ -32,7 +27,54 @@ axiod.create = (config?: IRequest) => {
   const instance = Object.assign({}, axiod);
   instance.defaults = Object.assign({}, axiod.defaults, config);
   instance.defaults.timeout = 1000;
-
+  instance.request = (options: IRequest): Promise<IAxiodResponse> => {
+    return axiod.request(Object.assign({}, instance.defaults, options));
+  };
+  instance.get = (url: string, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "get" }),
+    );
+  };
+  instance.post = (url: string, data?: Data, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "post", data }),
+    );
+  };
+  instance.put = (url: string, data?: Data, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "put", data }),
+    );
+  };
+  instance.delete = (url: string, data?: Data, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "delete", data }),
+    );
+  };
+  instance.options = (url: string, data?: Data, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "options", data }),
+    );
+  };
+  instance.head = (url: string, data?: Data, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "head", data }),
+    );
+  };
+  instance.connect = (url: string, data?: Data, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "connect", data }),
+    );
+  };
+  instance.trace = (url: string, data?: Data, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "trace", data }),
+    );
+  };
+  instance.patch = (url: string, data?: Data, config?: IConfig) => {
+    return instance.request(
+      Object.assign({}, { url }, config, { method: "patch", data }),
+    );
+  };
   return instance;
 };
 

--- a/request-methods.test.ts
+++ b/request-methods.test.ts
@@ -43,3 +43,10 @@ Deno.test("Axiod POST request with JSON data", async () => {
   assertEquals(data.data.data["foo1"], "bar1");
   assertEquals(data.data.data["foo2"], "bar2");
 });
+
+Deno.test("Axiod Create baseURL fix", async () => {
+  const ax = axiod.create({ baseURL: "https://postman-echo.com" });
+  const data = await ax.post("/post", { foo1: "bar1", foo2: "bar2" });
+  assertEquals(data.data.data["foo1"], "bar1");
+  assertEquals(data.data.data["foo2"], "bar2");
+});


### PR DESCRIPTION
Applied formatting
Added unit test for instance creation and usage

This fixes #2 which is caused by the `Object.assign` using the base `axiod` object's functions, which all refer to `axiod.request`

Doing this, it will always be calling with the regular defaults, since there is no actual inheritance involved with the `axiod.create` method. My fix here is quick and dirty, but I think binding `this` as the new instance and using `this` in the function calls could fix this much more cleanly.