### PR TITLE
Consider redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ axiod.get("/user/12345").catch((error) => {
 
 ```javascript
 // To test the module just run
-deno test --import-map ./import_map.json --allow-net
+deno test --allow-net
 ```
 
 ## License

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -26,6 +26,7 @@ export interface IConfig {
   paramsSerializer?: Function;
   transformRequest?: Array<TransformRequest>;
   transformResponse?: Array<TransformResponse>;
+  redirect?: RequestRedirect;
 }
 
 export interface IRequest extends IConfig {

--- a/mod.ts
+++ b/mod.ts
@@ -92,6 +92,7 @@ axiod.request = <T = any>({
   paramsSerializer,
   transformRequest,
   transformResponse,
+  redirect,
 }: IRequest): Promise<IAxiodResponse<T>> => {
   // Url and Base url
   if (baseURL) {
@@ -209,6 +210,10 @@ axiod.request = <T = any>({
     }, timeout);
   }
 
+  if (redirect) {
+    fetchRequestObject.redirect = redirect;
+  }
+
   // Start request
   return fetch(url, fetchRequestObject).then(async (x) => {
     // Clear timeout
@@ -262,6 +267,7 @@ axiod.request = <T = any>({
       withCredentials,
       auth,
       paramsSerializer,
+      redirect,
     };
 
     // Validate the status code
@@ -270,7 +276,7 @@ axiod.request = <T = any>({
     if (validateStatus) {
       isValidStatus = validateStatus(_status);
     } else {
-      isValidStatus = _status >= 200 && _status < 300;
+      isValidStatus = _status >= 200 && _status <= 303;
     }
 
     if (isValidStatus) {

--- a/mods/test-server.ts
+++ b/mods/test-server.ts
@@ -1,0 +1,29 @@
+import { serve } from "https://deno.land/std@0.118.0/http/server.ts";
+
+export class TestServer {
+    port: number;
+    controller = new AbortController()
+
+    constructor(port: number) {
+      this.port = port;
+      serve(this.handler, { port: this.port, signal: this.controller.signal });
+    }
+    
+    handler(request: Request): Response {
+      if (request.url.includes("redirect")) {
+          return new Response(null, {
+              status: 301,
+              headers: { 'Location': '/newlocation' }
+          });
+      }
+
+        if (request.url.includes("newlocation")) {
+            return new Response(null, { status: 200 });
+        }
+        return new Response(null, { status: 404 });
+    }
+
+    abort(): void {
+        this.controller.abort();
+    }
+}

--- a/redirect.test.ts
+++ b/redirect.test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "./mods/testing-assert.ts";
+import axiod from "./mod.ts";
+import { TestServer } from "./mods/test-server.ts"
+
+const port = 8080
+
+Deno.test("Axiod does not follow redirect", async () => {
+  const server = new TestServer(port);
+
+  const res = await axiod.get(
+    `http://localhost:${port}/redirect`,
+    { redirect: "manual" }
+  );
+
+  assertEquals(res.status, 301);
+  server.abort();
+});
+
+Deno.test("Axiod follows redirect", async () => {
+  const server = new TestServer(port);
+
+  const res = await axiod.get(
+    `http://localhost:${port}/redirect`,
+  );
+
+  assertEquals(res.status, 200);
+  server.abort();
+});


### PR DESCRIPTION
In Deno fetch, there is a possibility to not follow redirects automatically: https://deno.land/manual@v1.17.0/runtime/web_platform_apis#spec-deviations

I would propose to respond to redirects accordingly, if the property is set in the request options. This should work, if in the call of fetch the respective redirect property is set as in the request.

Please let me know what you think, and if you see any potential for improvement in the PR.