### PR TITLE
fix: correctly pass baseURL when using axiod.create()

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -23,10 +23,7 @@ function axiod<T = any>(
   if (typeof url === 'string') {
     return axiod.request(Object.assign({}, axiod.defaults, { url }, config));
   }
-  if (this.baseURL) {
-    return axiod.request(Object.assign({}, axiod.defaults, { baseURL: this.baseURL, url: url.url }));
-  }
-  return axiod.request(Object.assign({}, axiod.defaults, url));
+  return axiod.request(Object.assign({}, axiod.defaults, url, { baseURL: this.baseURL }));
 }
 
 axiod.defaults = {

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 import { urlJoin } from './mods/url-join.ts';
 
 import type {
@@ -14,11 +16,15 @@ import type {
 import { addInterceptor, methods } from './helpers.ts';
 
 function axiod<T = any>(
+  this: any,
   url: string | IRequest,
   config?: IRequest,
 ): Promise<IAxiodResponse<T>> {
   if (typeof url === 'string') {
     return axiod.request(Object.assign({}, axiod.defaults, { url }, config));
+  }
+  if (this.baseURL) {
+    return axiod.request(Object.assign({}, axiod.defaults, { baseURL: this.baseURL, url: url.url }));
   }
   return axiod.request(Object.assign({}, axiod.defaults, url));
 }
@@ -34,7 +40,12 @@ axiod.defaults = {
 };
 
 axiod.create = (config?: IRequest) => {
-  const instance = axiod.bind({});
+  let instance = axiod.bind({});
+  if (config && config.baseURL) {
+    instance = axiod.bind({
+      baseURL: config.baseURL
+    })
+  }
   instance.defaults = Object.assign({}, axiod.defaults, config);
 
   instance._request = request;
@@ -194,7 +205,7 @@ async function request<T = any>(this: typeof axiod, config: IRequest): Promise<I
       Array.isArray(transformRequest) &&
       transformRequest.length > 0
     ) {
-      for (var i = 0; i < (transformRequest || []).length; i++) {
+      for (let i = 0; i < (transformRequest || []).length; i++) {
         if (transformRequest && transformRequest[i]) {
           data = transformRequest[i](data, headers);
         }
@@ -216,7 +227,9 @@ async function request<T = any>(this: typeof axiod, config: IRequest): Promise<I
 
         headers['Accept'] = 'application/json';
         headers['Content-Type'] = 'application/json';
-      } catch (ex) {}
+      } catch {
+        // no-op
+      }
     }
   }
 
@@ -235,7 +248,7 @@ async function request<T = any>(this: typeof axiod, config: IRequest): Promise<I
   const controller = new AbortController();
   fetchRequestObject.signal = controller.signal;
 
-  let timeoutCounter: number = 0;
+  let timeoutCounter = 0;
 
   if ((timeout || 0) > 0) {
     timeoutCounter = setTimeout(() => {
@@ -278,7 +291,7 @@ async function request<T = any>(this: typeof axiod, config: IRequest): Promise<I
       } else {
         _data = await response.text();
       }
-    } catch (ex) {
+    } catch {
       _data = await x.clone().text();
     }
 
@@ -289,7 +302,7 @@ async function request<T = any>(this: typeof axiod, config: IRequest): Promise<I
         Array.isArray(transformResponse) &&
         transformResponse.length > 0
       ) {
-        for (var i = 0; i < (transformResponse || []).length; i++) {
+        for (let i = 0; i < (transformResponse || []).length; i++) {
           if (transformResponse && transformResponse[i]) {
             _data = transformResponse[i](_data);
           }


### PR DESCRIPTION
should fix #27

Along with the fix for the issue, also fixed some deno lint errors. Tested locally using the following code:

```ts
import axiod from "./mod.ts";
const ax = axiod.create({
  baseURL: 'https://www.google.com/'
})
ax({
  url: '/foo'
})
```

and it worked!